### PR TITLE
Fix bugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,9 @@ def main():
             if event.type == pygame.QUIT:
                 sys.exit()
             if event.type == pygame.KEYDOWN:
+                pressed_keys = pygame.key.get_pressed()
+                if pressed_keys.count(1) > 1:
+                    continue
                 snake.changedirection(event.key)
                 # 死后按space重新
                 if event.key == pygame.K_SPACE and isdead:


### PR DESCRIPTION
解决同时按下两个方向键，蛇立即死亡的问题。（例如：蛇在向下运动时，同时按住左方向键和上方向键，蛇会立刻死亡。）BUG的原因是KEYDOWN的判定失误，若同时按下两个方向键，蛇会向反方向开始运行，触发isdead判定，因此会立刻死亡。